### PR TITLE
Improve importer

### DIFF
--- a/django_project/core/settings/project.py
+++ b/django_project/core/settings/project.py
@@ -16,6 +16,7 @@ __copyright__ = ('Copyright 2023, Unicef')
 
 import os  # noqa
 
+from celery.schedules import crontab
 from django.utils.translation import ugettext_lazy as _
 
 from .contrib import *  # noqa
@@ -141,3 +142,11 @@ if USE_AZURE:
                               ] + AUTHENTICATION_BACKENDS
 
     AZURE_REGISTERED_CLIENT_IDS = [AZURE_AUTH['CLIENT_ID']]
+
+CELERY_BEAT_SCHEDULE = {
+    'fetch_datasets_nightly': {
+        'task': 'geosight.georepo.tasks.fetch_datasets',
+        'schedule': crontab(minute='0', hour='0'),
+        'args': (True,),
+    }
+}

--- a/django_project/geosight/georepo/admin/reference_layer.py
+++ b/django_project/geosight/georepo/admin/reference_layer.py
@@ -35,7 +35,7 @@ def update_meta(modeladmin, request, queryset):
         reference_layer.update_meta()
 
 
-@admin.action(description='Sync codes')
+@admin.action(description='Sync entities')
 def sync_codes(modeladmin, request, queryset):
     """Fetch new reference layer."""
     for reference_layer in queryset:

--- a/django_project/geosight/georepo/models/entity.py
+++ b/django_project/geosight/georepo/models/entity.py
@@ -87,7 +87,8 @@ class Entity(models.Model):
             original_id_type: str, original_id: str,
             reference_layer: ReferenceLayerView,
             admin_level: int = None,
-            date_time=timezone.now()
+            date_time=timezone.now(),
+            auto_fetch: bool = True
     ):
         """Return ucode for the code."""
         if not date_time:
@@ -126,10 +127,12 @@ class Entity(models.Model):
             if entity.admin_level != 0 and not entity.parents:
                 raise EntityCode.DoesNotExist()
         except (Entity.DoesNotExist, EntityCode.DoesNotExist):
+            if not auto_fetch:
+                raise GeorepoEntityDoesNotExist()
+
             entity = GeorepoRequest().View.find_entity(
                 reference_layer.identifier, original_id_type, original_id
             )
-
             obj, _ = Entity.objects.get_or_create(
                 reference_layer=reference_layer,
                 admin_level=entity.admin_level,

--- a/django_project/geosight/georepo/request/request.py
+++ b/django_project/geosight/georepo/request/request.py
@@ -16,6 +16,7 @@ __copyright__ = ('Copyright 2023, Unicef')
 
 import json
 import logging
+import time
 from urllib.parse import urlparse
 
 import requests
@@ -60,6 +61,53 @@ class GeorepoEntityDoesNotExist(Exception):
         message = 'Georepo entity does not exist.'
         logger.error(message)
         super().__init__(message)
+
+
+class GeorepoPostPooling:
+    """Georepo url with pooling."""
+
+    LIMIT = 100  # Check result maximum 100 times
+    INTERVAL = 2  # Interval of check results
+
+    def __init__(self, request, url, data):
+        """init."""
+        self.request = request
+        self.current_repeat = 0
+
+        response = request.post(url, data)
+        if response.status_code != 200:
+            raise GeorepoRequestError(
+                f"Identify codes error "
+                f"- {response.status_code} - {response.text}"
+            )
+        response = response.json()
+        try:
+            self.callback_url = response['status_url']
+        except KeyError:
+            raise GeorepoRequestError('Status url is not found.')
+
+    def results(self):
+        """Return results of data."""
+        self.current_repeat += 1
+        if self.current_repeat >= self.LIMIT:
+            raise requests.exceptions.Timeout()
+
+        response = self.request.get(self.callback_url)
+        if response.status_code != 200:
+            raise GeorepoRequestError(
+                f'{response.status_code} - {response.text}'
+            )
+        response = response.json()
+        if response['status'] == 'DONE':
+            return response['results']
+        elif response['status'] in ['ERROR', 'CANCELLED']:
+            try:
+                raise GeorepoRequestError(response['error'])
+            except KeyError:
+                raise GeorepoRequestError(response['status'])
+        else:
+            time.sleep(self.INTERVAL)
+            return self.results()
 
 
 class GeorepoUrl:
@@ -397,3 +445,24 @@ class GeorepoRequest:
                     pass
             response['features'] = features
             return response
+
+        def identify_codes_callback(self, url_callbacl):
+            """Return url callback."""
+
+        def identify_codes(
+                self, reference_layer_identifier: str, codes: list,
+                original_id_type: str, return_id_type: str
+        ):
+            """Identify codes and return the ucodes."""
+            url = (
+                f"{self.urls.georepo_url}/search/view/"
+                f"{reference_layer_identifier}/"
+                f"entity/batch/identifier/{original_id_type}/"
+                f"return_type/{return_id_type}/"
+            )
+            try:
+                return GeorepoPostPooling(self.request, url, codes).results()
+            except GeorepoRequestError as e:
+                raise GeorepoRequestError(
+                    f'Error when identifying codes - {e}'
+                )

--- a/django_project/geosight/georepo/request/request.py
+++ b/django_project/geosight/georepo/request/request.py
@@ -66,7 +66,7 @@ class GeorepoEntityDoesNotExist(Exception):
 class GeorepoPostPooling:
     """Georepo url with pooling."""
 
-    LIMIT = 100  # Check result maximum 100 times
+    LIMIT = 3000  # Check result maximum 1000 times
     INTERVAL = 2  # Interval of check results
 
     def __init__(self, request, url, data):
@@ -445,9 +445,6 @@ class GeorepoRequest:
                     pass
             response['features'] = features
             return response
-
-        def identify_codes_callback(self, url_callbacl):
-            """Return url callback."""
 
         def identify_codes(
                 self, reference_layer_identifier: str, codes: list,

--- a/django_project/geosight/georepo/tasks.py
+++ b/django_project/geosight/georepo/tasks.py
@@ -37,7 +37,7 @@ def fetch_reference_codes(_id):
 
 
 @app.task
-def fetch_datasets():
+def fetch_datasets(fetch_code=False):
     """Fetch reference codes."""
     datasets = GeorepoRequest().get_reference_layer_list()
     for dataset in datasets:
@@ -54,6 +54,8 @@ def fetch_datasets():
             )
             if created:
                 create_data_access_reference_layer_view(ref.id)
+            if fetch_code:
+                fetch_reference_codes(ref.id)
 
 
 @app.task

--- a/django_project/geosight/georepo/tests/mock.py
+++ b/django_project/geosight/georepo/tests/mock.py
@@ -21,9 +21,9 @@ from geosight.georepo.models.reference_layer import ReferenceLayerView
 def mock_get_entity(
         original_id_type: str, original_id: str,
         reference_layer: ReferenceLayerView, admin_level=None,
-        date_time=None
+        date_time=None, auto_fetch=True
 ):
-    """Mock for sharepoint request."""
+    """Mock for get entity request."""
     entity, _ = Entity.objects.get_or_create(
         reference_layer=reference_layer,
         geom_id=original_id,

--- a/django_project/geosight/importer/importers/base/indicator_value.py
+++ b/django_project/geosight/importer/importers/base/indicator_value.py
@@ -20,6 +20,7 @@ from datetime import datetime, date
 from typing import List
 
 from django.core.exceptions import ValidationError
+from requests.exceptions import Timeout
 
 from core.utils import string_is_true
 from geosight.data.models.indicator import (
@@ -309,7 +310,9 @@ class AbstractImporterIndicatorValue(BaseImporter, QueryDataImporter, ABC):
             indicator.validate(data['value'])
         return indicator
 
-    def get_entity(self, data, original_id_type: str):
+    def get_entity(
+            self, data, original_id_type: str, auto_fetch: bool = True
+    ):
         """Get entity of data."""
         from geosight.georepo.models.entity import Entity
         from geosight.georepo.request import (
@@ -324,7 +327,8 @@ class AbstractImporterIndicatorValue(BaseImporter, QueryDataImporter, ABC):
                 original_id_type=original_id_type,
                 original_id=adm_code,
                 admin_level=admin_level,
-                date_time=data['date_time']
+                date_time=data['date_time'],
+                auto_fetch=auto_fetch
             )
             return entity, None
         except GeorepoEntityDoesNotExist:
@@ -335,6 +339,22 @@ class AbstractImporterIndicatorValue(BaseImporter, QueryDataImporter, ABC):
             return None, f'{e}'
         except ValidationError:
             return None, 'This code does not exist because of error time.'
+
+    def check_codes(self, codes: list):
+        """Check codes to georepo."""
+        from geosight.georepo.request import GeorepoRequest
+        importer = self.importer
+        self._update('Identifying codes to GeoRepo')
+        try:
+            return GeorepoRequest().View.identify_codes(
+                reference_layer_identifier=importer.reference_layer.identifier,
+                original_id_type=importer.admin_code_type,
+                codes=codes,
+                return_id_type='ucode'
+
+            )
+        except Timeout:
+            raise ImporterError('Identifying codes to GeoRepo is timeout.')
 
     def _check_data_to_log(self, data: dict, note: dict) -> (dict, dict):
         """Save data that constructed from importer.
@@ -417,7 +437,7 @@ class AbstractImporterIndicatorValue(BaseImporter, QueryDataImporter, ABC):
             'aggregate_upper_level_n_level_up'
         )
         upper_level_count = 0
-        admin_level = int(record['admin_level'])
+        admin_level = entity.admin_level
         if aggregate_upper_level_up_to is not None:
             aggregate_upper_level_up_to = int(aggregate_upper_level_up_to)
             upper_level_count = admin_level - aggregate_upper_level_up_to
@@ -567,7 +587,7 @@ class AbstractImporterIndicatorValue(BaseImporter, QueryDataImporter, ABC):
 
                     upper_level_records = []
                     for record in _records:
-                        # We need to check the geopgraphy code
+                        # We need to check the geography code
                         entity, error = self.get_entity(record, 'ucode')
                         if not entity:
                             additional_notes.append(

--- a/django_project/geosight/importer/importers/base/indicator_value_long_format.py
+++ b/django_project/geosight/importer/importers/base/indicator_value_long_format.py
@@ -210,7 +210,7 @@ class IndicatorValueLongFormat(AbstractImporterIndicatorValue, ABC):
                         geo_code = record['geo_code']
                         codes = results[geo_code]
                         clean_records[idx]['geo_code'] = codes[len(codes) - 1]
-                    except IndexError:
+                    except (IndexError, KeyError):
                         notes[idx][code_type] = 'This code does not exist.'
                         success = False
 

--- a/django_project/geosight/importer/importers/base/indicator_value_long_format.py
+++ b/django_project/geosight/importer/importers/base/indicator_value_long_format.py
@@ -107,10 +107,17 @@ class IndicatorValueLongFormat(AbstractImporterIndicatorValue, ABC):
         total = len(records)
         adm_code_column = self.attributes['key_administration_code']
         value_column = self.get_attribute('key_value')
+        code_type = self.importer.admin_code_type
+
+        # Save the geocode that is not exist
+        checked_geocode = []
+        invalid_check_idx = []
 
         # Save the clean records
         clean_records = []
         notes = []
+        idx = 0
+
         for line_idx, record in enumerate(records):
             if not record:
                 continue
@@ -156,7 +163,6 @@ class IndicatorValueLongFormat(AbstractImporterIndicatorValue, ABC):
 
             # ----------------------------------------
             # Check the geocode
-            code_type = self.importer.admin_code_type
             data[code_type] = data['geo_code']
 
             # Check admin level
@@ -169,20 +175,43 @@ class IndicatorValueLongFormat(AbstractImporterIndicatorValue, ABC):
                 note['admin_level'] = 'Admin level is not integer'
 
             entity, error = self.get_entity(
-                data, self.importer.admin_code_type
+                data, self.importer.admin_code_type, auto_fetch=False
             )
             if entity:
                 data['geo_code'] = entity.geom_id
                 data['admin_level'] = entity.admin_level
             else:
-                note[code_type] = error
+                if error == 'This code does not exist.':
+                    checked_geocode.append(data['geo_code'])
+                    invalid_check_idx.append(idx)
+                else:
+                    note[code_type] = error
             # ----------------------------------------
 
             # Save to clean records
             clean_records.append(data)
             notes.append(note)
+            idx += 1
 
             # If there is note, failed
             if len(note.keys()):
                 success = False
+
+        # Checking missing geocode
+        if len(checked_geocode):
+            results = self.check_codes(codes=checked_geocode)
+            for idx in invalid_check_idx:
+                try:
+                    record = clean_records[idx]
+                except IndexError:
+                    pass
+                else:
+                    try:
+                        geo_code = record['geo_code']
+                        codes = results[geo_code]
+                        clean_records[idx]['geo_code'] = codes[len(codes) - 1]
+                    except IndexError:
+                        notes[idx][code_type] = 'This code does not exist.'
+                        success = False
+
         return clean_records, notes, success

--- a/django_project/geosight/importer/importers/base/indicator_value_wide_format.py
+++ b/django_project/geosight/importer/importers/base/indicator_value_wide_format.py
@@ -149,7 +149,7 @@ class IndicatorValueWideFormat(AbstractImporterIndicatorValue, ABC):
                         geo_code = record['geo_code']
                         codes = results[geo_code]
                         clean_records[idx]['geo_code'] = codes[len(codes) - 1]
-                    except IndexError:
+                    except (IndexError, KeyError):
                         notes[idx][code_type] = 'This code does not exist.'
                         success = False
 

--- a/django_project/geosight/importer/importers/base/indicator_value_wide_format.py
+++ b/django_project/geosight/importer/importers/base/indicator_value_wide_format.py
@@ -46,9 +46,15 @@ class IndicatorValueWideFormat(AbstractImporterIndicatorValue, ABC):
         success = True
         total = len(records)
         adm_code_column = self.get_attribute('key_administration_code')
+        code_type = self.importer.admin_code_type
+
+        # Save the geocode that is not exist
+        checked_geocode = []
+        invalid_check_idx = []
 
         clean_records = []
         notes = []
+        idx = 0
         for line_idx, record in enumerate(records):
             if not record:
                 continue
@@ -56,7 +62,7 @@ class IndicatorValueWideFormat(AbstractImporterIndicatorValue, ABC):
             # Update log
             self._update(
                 f'Processing line {line_idx}/{total}',
-                progress=int((line_idx / total) * 100)
+                progress=int((line_idx / total) * 50)
             )
 
             # ---------------------------------------
@@ -96,7 +102,6 @@ class IndicatorValueWideFormat(AbstractImporterIndicatorValue, ABC):
 
                     # ----------------------------------------
                     # Check the geocode
-                    code_type = self.importer.admin_code_type
                     data[code_type] = data['geo_code']
 
                     # Check admin level
@@ -109,21 +114,43 @@ class IndicatorValueWideFormat(AbstractImporterIndicatorValue, ABC):
                         note['admin_level'] = 'Admin level is not integer'
 
                     entity, error = self.get_entity(
-                        data, self.importer.admin_code_type
+                        data, self.importer.admin_code_type, auto_fetch=False
                     )
                     if entity:
                         data['geo_code'] = entity.geom_id
                         data['admin_level'] = entity.admin_level
                     else:
-                        note[code_type] = error
+                        if error == 'This code does not exist.':
+                            checked_geocode.append(data['geo_code'])
+                            invalid_check_idx.append(idx)
+                        else:
+                            note[code_type] = error
                     # ----------------------------------------
 
                     # Save to clean records
                     clean_records.append(data)
                     notes.append(note)
+                    idx += 1
 
                     # If there is not, failed
                     if len(note.keys()):
+                        success = False
+
+        # Checking missing geocode
+        if len(checked_geocode):
+            results = self.check_codes(codes=checked_geocode)
+            for idx in invalid_check_idx:
+                try:
+                    record = clean_records[idx]
+                except IndexError:
+                    pass
+                else:
+                    try:
+                        geo_code = record['geo_code']
+                        codes = results[geo_code]
+                        clean_records[idx]['geo_code'] = codes[len(codes) - 1]
+                    except IndexError:
+                        notes[idx][code_type] = 'This code does not exist.'
                         success = False
 
         return clean_records, notes, success

--- a/django_project/geosight/importer/tests/importers/_base.py
+++ b/django_project/geosight/importer/tests/importers/_base.py
@@ -138,6 +138,7 @@ class BaseIndicatorValueImporterTest(BaseImporterTest):
         importer.save_attributes(attributes, files)
         importer.run()
         log = importer.importerlog_set.all().last()
+        print(log.note)
         self.assertEqual(log.status, 'Success')
         all_tables = connection.introspection.table_names()
         self.assertTrue(importer.data_table_name not in all_tables)


### PR DESCRIPTION
This will fix https://github.com/unicef-drp/GeoSight/issues/1199

CC @janbur @timlinux 
This updates is already using batch API from GeoRepo (https://github.com/unicef-drp/GeoRepo/issues/1095)

This is mostly called when the code does not found in our cache.

**For the speed:**
Before
![Selection_040](https://github.com/unicef-drp/GeoSight-OS/assets/4530905/4ee93915-8bc4-49dd-aa34-040226977764)

After
![Selection_038](https://github.com/unicef-drp/GeoSight-OS/assets/4530905/67284f60-3666-444b-8ac8-43ae4621d42f)

**Notes:**
- Because from GeoRepo it does not return detail, there will be no "level" show on list (Because GeoSight does not know the detail of the entity)
![Selection_039](https://github.com/unicef-drp/GeoSight-OS/assets/4530905/f1e17ea2-054a-4a9e-b097-86b5f91f1032)

- On the aggregate, we still need to fetch the entity details from GeoRepo, because needs "parents" information to aggregate it. So if there is no cache, it will ask the API detail from GeoRepo, and it will slow as original issue.
- When saving data, GeoSight still needs entity detail, so the progress when saving data will also be slow
- I put nightly run for fetching entities from GeoRepo

I think, to prevent above issue, instead of just returning the ucodes, maybe we can return the detail of entity?
So when GeoSight validates the codes, it will also save the entity to cache?

I will make this PR as draft for now, continue after discussion later