### PR TITLE
feat: add indicator filters

### DIFF
--- a/django_project/core/api_utils.py
+++ b/django_project/core/api_utils.py
@@ -39,6 +39,7 @@ class ApiTag:
 
     BASEMAPS = 'Basemaps'
     DATA_BROWSER = 'Data Browser'
+    INDICATORS = 'indicators'
 
 
 class ApiParams:
@@ -163,5 +164,18 @@ class ApiParams:
         description=(
             'Filter data up to the date in format YYYY-MM-DD.'
         ),
+        type=openapi.TYPE_STRING
+    )
+    SHORTCODE_CONTAINS = openapi.Parameter(
+        'shortcode__contains',
+        openapi.IN_QUERY,
+        description='Filter data by shortcode.',
+        type=openapi.TYPE_STRING
+    )
+
+    CREATED_BY_CONTAINS = openapi.Parameter(
+        'created__by__contains',
+        openapi.IN_QUERY,
+        description='Filter data by created date.',
         type=openapi.TYPE_STRING
     )

--- a/django_project/geosight/data/api/v1/indicator.py
+++ b/django_project/geosight/data/api/v1/indicator.py
@@ -14,21 +14,51 @@ __author__ = 'irwan@kartoza.com'
 __date__ = '29/11/2023'
 __copyright__ = ('Copyright 2023, Unicef')
 
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets
 
 from geosight.data.models.indicator import Indicator
 from geosight.data.serializer.indicator import (
     IndicatorBasicListSerializer
 )
+
+from core.api_utils import ApiParams, common_api_params, ApiTag
 from .base import BaseApiV1
 
 
 class IndicatorViewSet(BaseApiV1, viewsets.ReadOnlyModelViewSet):
     """Indicator view set."""
 
+    model_class = Indicator
     serializer_class = IndicatorBasicListSerializer
+    extra_exclude_fields = ['parameters']
 
     @property
     def queryset(self):
         """Return the queryset."""
         return Indicator.permissions.list(self.request.user)
+
+    def get_queryset(self):
+        """Return queryset of API."""
+        query = self.queryset
+        return self.filter_query(
+            self.request, query, ['page', 'page_size']
+        )
+
+    @swagger_auto_schema(
+        operation_id='indicators-get',
+        tags=[ApiTag.INDICATORS],
+        manual_parameters=[
+            *common_api_params,
+            ApiParams.NAME_CONTAINS,
+            ApiParams.DESCRIPTION_CONTAINS,
+            ApiParams.SHORTCODE_CONTAINS,
+            ApiParams.CREATED_BY_CONTAINS,
+            ApiParams.PROJECT_SLUGS,
+            ApiParams.PROJECT_IDS
+        ],
+        operation_description='Return list of accessed indicators for the user.'
+    )
+    def list(self, request, *args, **kwargs):
+        """List of indicators."""
+        return super().list(request, *args, **kwargs)


### PR DESCRIPTION
Added new parameters to the /indicator endpoint. Can be seen in swagger at /api/v1/docs/
Parameters are:
1. `name__contains`
2. `shortcode__contains`
3. `project_slug__in`
4. `project_id__in`
5. `description__contains`
6. `created__by__contains`

Example request:
http://localhost:2000/api/v1/indicators/?page=1&page_size=25&name__contains=Ind

Fixes #156