### PR TITLE
Implement GET /api/v1/related-tables/

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -79,6 +79,8 @@ services:
     container_name: "geosight_db"
     volumes:
       - database:/var/lib/postgresql/13
+    ports:
+      - "5432:5432"
     environment:
       - ALLOW_IP_RANGE=0.0.0.0/0
       - POSTGRES_DBNAME=${DATABASE_NAME:-django}

--- a/django_project/core/api_utils.py
+++ b/django_project/core/api_utils.py
@@ -38,6 +38,7 @@ class ApiTag:
     """Return API Tags."""
 
     BASEMAPS = 'Basemaps'
+    RELATED_TABLES = 'Related tables'
     DATA_BROWSER = 'Data Browser'
 
 

--- a/django_project/core/tests/base_tests.py
+++ b/django_project/core/tests/base_tests.py
@@ -80,18 +80,25 @@ class BaseTest:
         self.assertEquals(response.status_code, code)
         return response
 
-    def assertResponseContainsPaginatedList(self, response, validation_function, *resources):
+    def assertResponseContainsPaginatedList(
+            self, response, validation_function, *resources
+    ):
         """
-        Assert the GET response contains a JSON array with exactly the same elements representing
-         the given resources, in any order.
+        Assert GET response against resources.
+
+        Assert the GET response contains a JSON array with exactly the same
+         elements representing the given resources, in any order.
 
         :param response: GET response
-        :param validation_function: A function receiving a json object from the response and a resource
-        and returning a boolean determining whether the json object represents the resource or not.
+        :param validation_function: A function receiving a json object from
+         the response and a resource
+         and returning a boolean determining whether the json object represents
+         the resource or not.
         """
         assert response.status_code == 200
         results = response.json().get('results')
 
         assert len(results) == len(resources)
         for resource in resources:
-            assert any(validation_function(json_obj, resource) for json_obj in results)
+            assert any(validation_function(json_obj, resource)
+                       for json_obj in results)

--- a/django_project/core/tests/base_tests.py
+++ b/django_project/core/tests/base_tests.py
@@ -80,7 +80,7 @@ class BaseTest:
         self.assertEquals(response.status_code, code)
         return response
 
-    def assertResponseContainsList(self, response, validation_function, *resources):
+    def assertResponseContainsPaginatedList(self, response, validation_function, *resources):
         """
         Assert the GET response contains a JSON array with exactly the same elements representing
          the given resources, in any order.
@@ -90,8 +90,8 @@ class BaseTest:
         and returning a boolean determining whether the json object represents the resource or not.
         """
         assert response.status_code == 200
-        json = response.json()
+        results = response.json().get('results')
 
-        assert len(json) == len(resources)
+        assert len(results) == len(resources)
         for resource in resources:
-            assert any(validation_function(json_obj, resource) for json_obj in json)
+            assert any(validation_function(json_obj, resource) for json_obj in results)

--- a/django_project/core/tests/base_tests.py
+++ b/django_project/core/tests/base_tests.py
@@ -79,3 +79,19 @@ class BaseTest:
         response = client.delete(url, data=data, content_type=content_type)
         self.assertEquals(response.status_code, code)
         return response
+
+    def assertResponseContainsList(self, response, validation_function, *resources):
+        """
+        Assert the GET response contains a JSON array with exactly the same elements representing
+         the given resources, in any order.
+
+        :param response: GET response
+        :param validation_function: A function receiving a json object from the response and a resource
+        and returning a boolean determining whether the json object represents the resource or not.
+        """
+        assert response.status_code == 200
+        json = response.json()
+
+        assert len(json) == len(resources)
+        for resource in resources:
+            assert any(validation_function(json_obj, resource) for json_obj in json)

--- a/django_project/geosight/data/api/v1/related_table.py
+++ b/django_project/geosight/data/api/v1/related_table.py
@@ -1,0 +1,50 @@
+from drf_yasg.openapi import Response
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.exceptions import MethodNotAllowed
+
+from core.api_utils import ApiTag
+from geosight.data.api.v1.base import BaseApiV1Resource
+from geosight.data.models import RelatedTable
+from geosight.data.serializer.related_table import RelatedTableApiSerializer
+
+
+class RelatedTableViewSet(BaseApiV1Resource):
+    model_class = RelatedTable
+    serializer_class = RelatedTableApiSerializer
+    extra_exclude_fields = []
+    pagination_class = None
+
+    @swagger_auto_schema(
+        operation_id='related-tables-get',
+        tags=[ApiTag.RELATED_TABLES],
+        operation_description='Return list of accessible related tables for the user.',
+        responses={
+            200: Response(
+                description="Resource fetching successful.",
+                schema=RelatedTableApiSerializer(many=True)
+            )
+        }
+    )
+    def list(self, request, *args, **kwargs):
+        """List of related tables."""
+        return super().list(request, *args, **kwargs)
+
+    @swagger_auto_schema(operation_id='related-tables-get', tags=[ApiTag.RELATED_TABLES])
+    def retrieve(self, request, *args, **kwargs):
+        raise MethodNotAllowed('GET')
+
+    @swagger_auto_schema(operation_id='related-tables-create', tags=[ApiTag.RELATED_TABLES])
+    def create(self, request, *args, **kwargs):
+        raise MethodNotAllowed('POST')
+
+    @swagger_auto_schema(operation_id='related-tables-update', tags=[ApiTag.RELATED_TABLES])
+    def update(self, request, *args, **kwargs):
+        raise MethodNotAllowed('PUT')
+
+    @swagger_auto_schema(operation_id='related-tables-partial_update', tags=[ApiTag.RELATED_TABLES])
+    def partial_update(self, request, *args, **kwargs):
+        raise MethodNotAllowed('PATCH')
+
+    @swagger_auto_schema(operation_id='related-tables-delete', tags=[ApiTag.RELATED_TABLES])
+    def destroy(self, request, *args, **kwargs):
+        raise MethodNotAllowed('DELETE')

--- a/django_project/geosight/data/api/v1/related_table.py
+++ b/django_project/geosight/data/api/v1/related_table.py
@@ -1,3 +1,18 @@
+"""
+GeoSight is UNICEF's geospatial web-based business intelligence platform.
+
+Contact : geosight-no-reply@unicef.org
+
+.. note:: This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+"""
+__author__ = 'Víctor González'
+__date__ = '29/01/2024'
+__copyright__ = ('Copyright 2023, Unicef')
+
 from drf_yasg.openapi import Response
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.exceptions import MethodNotAllowed
@@ -12,7 +27,6 @@ class RelatedTableViewSet(BaseApiV1Resource):
     model_class = RelatedTable
     serializer_class = RelatedTableApiSerializer
     extra_exclude_fields = []
-    pagination_class = None
 
     @swagger_auto_schema(
         operation_id='related-tables-get',

--- a/django_project/geosight/data/api/v1/related_table.py
+++ b/django_project/geosight/data/api/v1/related_table.py
@@ -24,6 +24,8 @@ from geosight.data.serializer.related_table import RelatedTableApiSerializer
 
 
 class RelatedTableViewSet(BaseApiV1Resource):
+    """Related Table ViewSet."""
+
     model_class = RelatedTable
     serializer_class = RelatedTableApiSerializer
     extra_exclude_fields = []
@@ -31,7 +33,8 @@ class RelatedTableViewSet(BaseApiV1Resource):
     @swagger_auto_schema(
         operation_id='related-tables-get',
         tags=[ApiTag.RELATED_TABLES],
-        operation_description='Return list of accessible related tables for the user.',
+        operation_description=
+        'Return list of accessible related tables for the user.',
         responses={
             200: Response(
                 description="Resource fetching successful.",
@@ -43,22 +46,32 @@ class RelatedTableViewSet(BaseApiV1Resource):
         """List of related tables."""
         return super().list(request, *args, **kwargs)
 
-    @swagger_auto_schema(operation_id='related-tables-get', tags=[ApiTag.RELATED_TABLES])
+    @swagger_auto_schema(operation_id='related-tables-get',
+                         tags=[ApiTag.RELATED_TABLES])
     def retrieve(self, request, *args, **kwargs):
+        """Detail of related table."""
         raise MethodNotAllowed('GET')
 
-    @swagger_auto_schema(operation_id='related-tables-create', tags=[ApiTag.RELATED_TABLES])
+    @swagger_auto_schema(operation_id='related-tables-create',
+                         tags=[ApiTag.RELATED_TABLES])
     def create(self, request, *args, **kwargs):
+        """Create a related table."""
         raise MethodNotAllowed('POST')
 
-    @swagger_auto_schema(operation_id='related-tables-update', tags=[ApiTag.RELATED_TABLES])
+    @swagger_auto_schema(operation_id='related-tables-update',
+                         tags=[ApiTag.RELATED_TABLES])
     def update(self, request, *args, **kwargs):
+        """Update an existing related table."""
         raise MethodNotAllowed('PUT')
 
-    @swagger_auto_schema(operation_id='related-tables-partial_update', tags=[ApiTag.RELATED_TABLES])
+    @swagger_auto_schema(operation_id='related-tables-partial_update',
+                         tags=[ApiTag.RELATED_TABLES])
     def partial_update(self, request, *args, **kwargs):
+        """Update an existing related table."""
         raise MethodNotAllowed('PATCH')
 
-    @swagger_auto_schema(operation_id='related-tables-delete', tags=[ApiTag.RELATED_TABLES])
+    @swagger_auto_schema(operation_id='related-tables-delete',
+                         tags=[ApiTag.RELATED_TABLES])
     def destroy(self, request, *args, **kwargs):
+        """Delete an existing related table."""
         raise MethodNotAllowed('DELETE')

--- a/django_project/geosight/data/serializer/related_table.py
+++ b/django_project/geosight/data/serializer/related_table.py
@@ -15,6 +15,8 @@ __date__ = '13/06/2023'
 __copyright__ = ('Copyright 2023, Unicef')
 
 from django.shortcuts import reverse
+from django.utils import deprecation
+from pylint.checkers import deprecated
 from rest_framework import serializers
 
 from core.serializer.dynamic_serializer import DynamicModelSerializer
@@ -23,8 +25,33 @@ from geosight.data.models.related_table import (
 )
 
 
+class RelatedTableApiSerializer(DynamicModelSerializer):
+    url = serializers.SerializerMethodField()
+    creator = serializers.SerializerMethodField()
+    fields_definition = serializers.SerializerMethodField()
+
+    def get_url(self, obj: RelatedTable):
+        return reverse(
+            'related-tables-detail',
+            args=[obj.id]
+        )
+
+    def get_creator(self, obj: RelatedTable):
+        return obj.creator.get_full_name() if obj.creator else None
+
+    def get_fields_definition(self, obj: RelatedTable):
+        return obj.fields_definition
+
+    class Meta:
+        model = RelatedTable
+        exclude = ('unique_id',)
+
+
 class RelatedTableSerializer(DynamicModelSerializer):
-    """Serializer for RelatedTable."""
+    """
+    DEPRECATED: Legacy serializer, to be replaced with RelatedTableApiSerializer
+    Serializer for RelatedTable.
+    """
 
     url = serializers.SerializerMethodField()
     creator = serializers.SerializerMethodField()

--- a/django_project/geosight/data/serializer/related_table.py
+++ b/django_project/geosight/data/serializer/related_table.py
@@ -15,8 +15,6 @@ __date__ = '13/06/2023'
 __copyright__ = ('Copyright 2023, Unicef')
 
 from django.shortcuts import reverse
-from django.utils import deprecation
-from pylint.checkers import deprecated
 from rest_framework import serializers
 
 from core.serializer.dynamic_serializer import DynamicModelSerializer

--- a/django_project/geosight/data/serializer/related_table.py
+++ b/django_project/geosight/data/serializer/related_table.py
@@ -24,31 +24,34 @@ from geosight.data.models.related_table import (
 
 
 class RelatedTableApiSerializer(DynamicModelSerializer):
+    """Serializer for RelatedTable."""
+
     url = serializers.SerializerMethodField()
     creator = serializers.SerializerMethodField()
     fields_definition = serializers.SerializerMethodField()
 
-    def get_url(self, obj: RelatedTable):
+    def get_url(self, obj: RelatedTable):  # noqa: D102
         return reverse(
             'related-tables-detail',
             args=[obj.id]
         )
 
-    def get_creator(self, obj: RelatedTable):
+    def get_creator(self, obj: RelatedTable):  # noqa: D102
         return obj.creator.get_full_name() if obj.creator else None
 
-    def get_fields_definition(self, obj: RelatedTable):
+    def get_fields_definition(self, obj: RelatedTable):  # noqa: D102
         return obj.fields_definition
 
-    class Meta:
+    class Meta:  # noqa: D106
         model = RelatedTable
         exclude = ('unique_id',)
 
 
 class RelatedTableSerializer(DynamicModelSerializer):
     """
-    DEPRECATED: Legacy serializer, to be replaced with RelatedTableApiSerializer
-    Serializer for RelatedTable.
+    DEPRECATED: Legacy serializer.
+
+    To be replaced with RelatedTableApiSerializer Serializer for RelatedTable.
     """
 
     url = serializers.SerializerMethodField()

--- a/django_project/geosight/data/tests/api/v1/related_table.py
+++ b/django_project/geosight/data/tests/api/v1/related_table.py
@@ -24,8 +24,8 @@ from geosight.permission.models import PERMISSIONS
 from geosight.permission.tests import BasePermissionTest
 
 
-class RelatedTableApiTest(BasePermissionTest, TestCase):
-    def setUp(self):
+class RelatedTableApiTest(BasePermissionTest, TestCase):  # noqa: D101
+    def setUp(self):  # noqa: D102
         super().setUp()
 
         self.resource_1 = RelatedTable.permissions.create(
@@ -42,16 +42,20 @@ class RelatedTableApiTest(BasePermissionTest, TestCase):
             name='Name C',
             description='Resource 3',
         )
-        self.resource_3.permission.update_user_permission(self.creator, PERMISSIONS.LIST)
-        self.resource_3.permission.update_group_permission(self.group, PERMISSIONS.OWNER)
+        self.resource_3.permission.update_user_permission(
+            self.creator, PERMISSIONS.LIST)
+        self.resource_3.permission.update_group_permission(
+            self.group, PERMISSIONS.OWNER)
 
     def test_list(self):
+        """Test GET /related-tables/ ."""
         url = reverse('related-tables-list') + '?all_fields=true'
         self.assertRequestGetView(url, 403)
 
         response = self.assertRequestGetView(url, 200, user=self.admin)
         self.assertResponseContainsPaginatedList(
-            response, validate_related_table, self.resource_1, self.resource_2, self.resource_3
+            response, validate_related_table,
+            self.resource_1, self.resource_2, self.resource_3
         )
 
         response = self.assertRequestGetView(url, 200, user=self.viewer)
@@ -60,23 +64,26 @@ class RelatedTableApiTest(BasePermissionTest, TestCase):
         response = self.assertRequestGetView(url, 200, user=self.creator)
         self.assertEqual(len(response.json().get('results')), 1)
 
-        response = self.assertRequestGetView(url, 200, user=self.creator_in_group)
+        response = self.assertRequestGetView(url, 200,
+                                             user=self.creator_in_group)
         self.assertEqual(len(response.json().get('results')), 1)
 
-    def create_resource(self, user):
+    def create_resource(self, user):  # noqa: D102
         return None
 
 
 def validate_related_table(json, resource):
-    return (json['id'] == resource.id
-            and json['name'] == resource.name
-            and json.get('description') == resource.description
-            and json['url'] == f'/api/v1/related-tables/{resource.id}/'
-            and json.get('creator') == resource.creator.get_full_name()
-            and to_datetime(json, 'created_at') == resource.created_at
-            and to_datetime(json, 'modified_at') == resource.modified_at)
+    """Validate json dict against resource."""
+    return (json['id'] == resource.id and
+            json['name'] == resource.name and
+            json.get('description') == resource.description and
+            json['url'] == f'/api/v1/related-tables/{resource.id}/' and
+            json.get('creator') == resource.creator.get_full_name() and
+            to_datetime(json, 'created_at') == resource.created_at and
+            to_datetime(json, 'modified_at') == resource.modified_at)
 
 
 def to_datetime(json, attribute) -> datetime.datetime:
+    """Convert a JSON attribute into a datetime."""
     date = json.get(attribute)
     return parser.parse(date) if date else None

--- a/django_project/geosight/data/tests/api/v1/related_table.py
+++ b/django_project/geosight/data/tests/api/v1/related_table.py
@@ -1,0 +1,82 @@
+import datetime
+
+from dateutil import parser
+from django.test.testcases import TestCase
+from rest_framework.reverse import reverse
+
+from geosight.data.models import RelatedTable
+from geosight.permission.models import PERMISSIONS
+from geosight.permission.tests import BasePermissionTest
+
+
+class RelatedTableApiTest(BasePermissionTest, TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.resource_1 = RelatedTable.permissions.create(
+            user=self.resource_creator,
+            name='Name A',
+        )
+        self.resource_2 = RelatedTable.permissions.create(
+            user=self.resource_creator,
+            name='Name B',
+            description='This is test',
+        )
+        self.resource_3 = RelatedTable.permissions.create(
+            user=self.resource_creator,
+            name='Name C',
+            description='Resource 3',
+        )
+        self.resource_3.permission.update_user_permission(self.creator, PERMISSIONS.LIST)
+        self.resource_3.permission.update_group_permission(self.group, PERMISSIONS.OWNER)
+
+    def test_list(self):
+        url = reverse('related-tables-list') + '?all_fields=true'
+        self.assertRequestGetView(url, 403)
+
+        response = self.assertRequestGetView(url, 200, user=self.admin)
+        self.assertResponseContainsList(
+            response, validate_related_table, self.resource_1, self.resource_2, self.resource_3
+        )
+
+        response = self.assertRequestGetView(url, 200, user=self.viewer)
+        self.assertEqual(len(response.json()), 0)
+
+        response = self.assertRequestGetView(url, 200, user=self.creator)
+        self.assertEqual(len(response.json()), 1)
+
+        response = self.assertRequestGetView(url, 200, user=self.creator_in_group)
+        self.assertEqual(len(response.json()), 1)
+
+    def test_detail_api(self):
+        url = reverse('related-tables-detail', args=[0])
+        self.assertRequestGetView(url, 403)
+        self.assertRequestGetView(url, 404, user=self.viewer)
+        self.assertRequestGetView(url, 404, user=self.creator)
+        self.assertRequestGetView(url, 404, user=self.admin)
+
+        url = reverse('related-tables-detail', kwargs={'id': self.resource_3.id}) + '?all_fields=true'
+        self.assertRequestGetView(url, 403)
+        self.assertRequestGetView(url, 403, user=self.viewer)
+        self.assertRequestGetView(url, 403, user=self.creator)
+        response = self.assertRequestGetView(url, 200, user=self.admin)
+
+        assert validate_related_table(response.json(), self.resource_3)
+
+    def create_resource(self, user):
+        return None
+
+
+def validate_related_table(json, resource):
+    return (json['id'] == resource.id
+            and json['name'] == resource.name
+            and json.get('description') == resource.description
+            and json['url'] == f'/api/v1/related-tables/{resource.id}/'
+            and json.get('creator') == resource.creator.get_full_name()
+            and to_datetime(json, 'created_at') == resource.created_at
+            and to_datetime(json, 'modified_at') == resource.modified_at)
+
+
+def to_datetime(json, attribute) -> datetime.datetime:
+    date = json.get(attribute)
+    return parser.parse(date) if date else None

--- a/django_project/geosight/data/tests/api/v1/related_table.py
+++ b/django_project/geosight/data/tests/api/v1/related_table.py
@@ -1,3 +1,18 @@
+"""
+GeoSight is UNICEF's geospatial web-based business intelligence platform.
+
+Contact : geosight-no-reply@unicef.org
+
+.. note:: This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+"""
+__author__ = 'Víctor González'
+__date__ = '29/01/2024'
+__copyright__ = ('Copyright 2023, Unicef')
+
 import datetime
 
 from dateutil import parser
@@ -35,33 +50,18 @@ class RelatedTableApiTest(BasePermissionTest, TestCase):
         self.assertRequestGetView(url, 403)
 
         response = self.assertRequestGetView(url, 200, user=self.admin)
-        self.assertResponseContainsList(
+        self.assertResponseContainsPaginatedList(
             response, validate_related_table, self.resource_1, self.resource_2, self.resource_3
         )
 
         response = self.assertRequestGetView(url, 200, user=self.viewer)
-        self.assertEqual(len(response.json()), 0)
+        self.assertEqual(len(response.json().get('results')), 0)
 
         response = self.assertRequestGetView(url, 200, user=self.creator)
-        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(len(response.json().get('results')), 1)
 
         response = self.assertRequestGetView(url, 200, user=self.creator_in_group)
-        self.assertEqual(len(response.json()), 1)
-
-    def test_detail_api(self):
-        url = reverse('related-tables-detail', args=[0])
-        self.assertRequestGetView(url, 403)
-        self.assertRequestGetView(url, 404, user=self.viewer)
-        self.assertRequestGetView(url, 404, user=self.creator)
-        self.assertRequestGetView(url, 404, user=self.admin)
-
-        url = reverse('related-tables-detail', kwargs={'id': self.resource_3.id}) + '?all_fields=true'
-        self.assertRequestGetView(url, 403)
-        self.assertRequestGetView(url, 403, user=self.viewer)
-        self.assertRequestGetView(url, 403, user=self.creator)
-        response = self.assertRequestGetView(url, 200, user=self.admin)
-
-        assert validate_related_table(response.json(), self.resource_3)
+        self.assertEqual(len(response.json().get('results')), 1)
 
     def create_resource(self, user):
         return None

--- a/django_project/geosight/data/tests/api/v1/related_table.py
+++ b/django_project/geosight/data/tests/api/v1/related_table.py
@@ -84,6 +84,6 @@ def validate_related_table(json, resource):
 
 
 def to_datetime(json, attribute) -> datetime.datetime:
-    """Convert a JSON attribute into a datetime."""
+    """Convert a json attribute into a datetime."""
     date = json.get(attribute)
     return parser.parse(date) if date else None

--- a/django_project/geosight/data/urls_v1.py
+++ b/django_project/geosight/data/urls_v1.py
@@ -28,7 +28,8 @@ from geosight.data.api.v1.related_table import RelatedTableViewSet
 
 router = DefaultRouter()
 router.register(r'basemaps', BasemapViewSet, basename='basemaps')
-router.register(r'related-tables', RelatedTableViewSet, basename='related-tables')
+router.register(
+    r'related-tables', RelatedTableViewSet, basename='related-tables')
 router.register(r'indicators', IndicatorViewSet, basename='indicators')
 
 data_browser_api_v1 = [

--- a/django_project/geosight/data/urls_v1.py
+++ b/django_project/geosight/data/urls_v1.py
@@ -24,9 +24,11 @@ from geosight.data.api.v1.data_browser import (
     DatasetApiList, DatasetApiListIds
 )
 from geosight.data.api.v1.indicator import IndicatorViewSet
+from geosight.data.api.v1.related_table import RelatedTableViewSet
 
 router = DefaultRouter()
 router.register(r'basemaps', BasemapViewSet, basename='basemaps')
+router.register(r'related-tables', RelatedTableViewSet, basename='related-tables')
 router.register(r'indicators', IndicatorViewSet, basename='indicators')
 
 data_browser_api_v1 = [


### PR DESCRIPTION
Implements #194.

Needs a different (writable for future endpoints) `fields_definition` in the model for this to really implement #194 .

Since it's my first PR it would be nice to get an early review just to check I'm following your code guidelines and I'm not forgetting anything major when implementing new endpoints in the API.