### PR TITLE
Do not style nodata or anything under minimum band

### DIFF
--- a/django_project/frontend/package.json
+++ b/django_project/frontend/package.json
@@ -47,7 +47,7 @@
     "webpack": "^5.72.0",
     "webpack-bundle-tracker": "^1.5.0",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.9.0"
+    "webpack-dev-server": "^4.15.2"
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.16.7",
@@ -57,7 +57,7 @@
     "@dnd-kit/utilities": "^3.2.0",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@geomatico/maplibre-cog-protocol": "^0.3.1",
+    "@geomatico/maplibre-cog-protocol": "^0.4.0",
     "@mapbox/mapbox-gl-draw": "^1.3.0",
     "@mdxeditor/editor": "^1.5.0",
     "@mui/icons-material": "^5.6.2",

--- a/django_project/frontend/src/pages/Dashboard/MapLibre/LayerType/RasterCog.jsx
+++ b/django_project/frontend/src/pages/Dashboard/MapLibre/LayerType/RasterCog.jsx
@@ -48,7 +48,8 @@ export default function rasterCogLayer(map, id, data, contextLayerData, popupFea
       if (!colors.length) {
         return
       }
-      const url = `cog://${data.url}`;
+      // TODO: Handle styling when multiple, identical COG URLs are used
+      const url = `cog://${data.url}#` + contextLayerData.id;
 
       removeSource(map, id)
 

--- a/django_project/frontend/src/pages/Dashboard/MapLibre/LayerType/RasterCog.jsx
+++ b/django_project/frontend/src/pages/Dashboard/MapLibre/LayerType/RasterCog.jsx
@@ -48,7 +48,7 @@ export default function rasterCogLayer(map, id, data, contextLayerData, popupFea
       if (!colors.length) {
         return
       }
-      const url = `cog://${data.url}`
+      const url = `cog://${data.url}`;
 
       removeSource(map, id)
 
@@ -63,14 +63,14 @@ export default function rasterCogLayer(map, id, data, contextLayerData, popupFea
           dynamic_class_num - 1 // Ensure the index does not exceed the array length
         );
         try {
-          return  result = hexToRgba(colors[index], 1);
+          return hexToRgba(colors[index], 255);
         } catch (e) {
           return [0, 0, 0 , 0];
         }
       };
 
       setColorFunction(data.url, ([value], rgba, {noData}) => {
-        if (value === noData || value === Infinity || isNaN(value) || value < min_band) {
+      if (value === noData || value === Infinity || isNaN(value) || value < min_band || value > max_band) {
           rgba.set([0, 0, 0, 0]); // noData, fillValue or NaN => transparent
         } else {
           rgba.set(getColor(value));

--- a/django_project/frontend/src/pages/Dashboard/MapLibre/LayerType/RasterCog.jsx
+++ b/django_project/frontend/src/pages/Dashboard/MapLibre/LayerType/RasterCog.jsx
@@ -26,6 +26,9 @@ import {
 import { createColorsFromPaletteId } from "../../../../utils/Style";
 import { sleep } from "../../../../utils/main";
 import { getCogFeatureByPoint } from "../../../../utils/COGLayer";
+import {setColorFunction} from '@geomatico/maplibre-cog-protocol';
+import {hexToRgba} from '../utils';
+
 
 /***
  * Render Raster Cog
@@ -45,9 +48,34 @@ export default function rasterCogLayer(map, id, data, contextLayerData, popupFea
       if (!colors.length) {
         return
       }
-      const url = `cog://${data.url}#color:[${colors.map(color => '"' + color + '"')}],${min_band ? min_band : 0},${max_band ? max_band : 100},c`
+      const url = `cog://${data.url}`
 
       removeSource(map, id)
+
+      const getColor = (value) => {
+        if (value < min_band || value > max_band) {
+          throw new Error("Value is out of range");
+        }
+
+        const interval = (max_band - min_band) / dynamic_class_num; // Calculate interval size
+        const index = Math.min(
+          Math.floor((value - min_band) / interval),
+          dynamic_class_num - 1 // Ensure the index does not exceed the array length
+        );
+        try {
+          return  result = hexToRgba(colors[index], 1);
+        } catch (e) {
+          return [0, 0, 0 , 0];
+        }
+      };
+
+      setColorFunction(data.url, ([value], rgba, {noData}) => {
+        if (value === noData || value === Infinity || isNaN(value) || value < min_band) {
+          rgba.set([0, 0, 0, 0]); // noData, fillValue or NaN => transparent
+        } else {
+          rgba.set(getColor(value));
+        }
+      });
       const sourceParams = Object.assign({}, data.params, {
         url: url,
         type: 'raster',

--- a/django_project/frontend/src/pages/Dashboard/MapLibre/utils.js
+++ b/django_project/frontend/src/pages/Dashboard/MapLibre/utils.js
@@ -288,3 +288,19 @@ export const getLayerIdOfReferenceLayer = (map) => {
   const first = map.getStyle().layers.filter(layer => layer.id.includes(FILL_LAYER_ID_KEY))[0]
   return first?.id
 };
+
+export const hexToRgba = (hex, alpha = 1, format = 'array') => {
+  // Remove the hash if present
+  const hexClean = hex.replace("#", "");
+
+  // Parse the R, G, and B values
+  const r = parseInt(hexClean.substring(0, 2), 16);
+  const g = parseInt(hexClean.substring(2, 4), 16);
+  const b = parseInt(hexClean.substring(4, 6), 16);
+
+  // Return in RGBA format
+  if (format == 'array') {
+    return [r, g, b, alpha]
+  }
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};


### PR DESCRIPTION
This is PR for https://github.com/unicef-drp/GeoSight/issues/19.
I use latest geomatico library and update the `setColorFunction`, so if the value equals to nodata or less than min value or more than max value, it will be transparent