### PR TITLE
Feature/1518 show number comma

### DIFF
--- a/django_project/frontend/src/components/ZonalAnalysisTool/Result.tsx
+++ b/django_project/frontend/src/components/ZonalAnalysisTool/Result.tsx
@@ -29,6 +29,7 @@ import { fetchFromAPIValues } from "./fetchFromAPIValues";
 
 import './style.scss';
 import Tooltip from "@mui/material/Tooltip";
+import {getAreaDecimalLength, numberWithCommas} from "../../utils/main";
 
 interface Props {
   index: number;
@@ -156,7 +157,7 @@ export const ZonalAnalysisResult = forwardRef((
             isAnalyzing ? <i>Loading</i> : error ?
               <i className='Error'>
                 {error}
-              </i> : ![null, NaN].includes(value) ? value : '-'
+              </i> : ![null, NaN].includes(value) ? numberWithCommas(value, getAreaDecimalLength(value)) : '-'
           }
         </td>
       </tr>


### PR DESCRIPTION
This is PR for https://github.com/unicef-drp/GeoSight/issues/1518
Previously, the comma in number and rounding were only applied to area and perimeter of the drawn/selected geometry. Also apply it to zonal analysis result:
![Screenshot_20250203_084702](https://github.com/user-attachments/assets/6dcc3cce-4c76-4e61-a1ce-76f81e94a83b)
