### PR TITLE
Handle error on dashboard edit and create

### DIFF
--- a/django_project/frontend/tests/admin/dashboard.py
+++ b/django_project/frontend/tests/admin/dashboard.py
@@ -317,9 +317,3 @@ class DashboardAdminViewTest(BaseViewTest.TestCase):
         self.assertEqual(self.resource.modified_by, self.resource.creator)
         last_version = self.resource.version
         self.assertEqual(self.resource.version, last_version)
-
-    def test_extent_invalid(self):
-        """Test for create view with invalid extent."""
-
-        url = reverse(self.create_url_tag)
-

--- a/django_project/frontend/tests/admin/dashboard.py
+++ b/django_project/frontend/tests/admin/dashboard.py
@@ -123,6 +123,35 @@ class DashboardAdminViewTest(BaseViewTest.TestCase):
         self.assertRequestGetView(url, 403, self.resource_creator)  # Creator
         self.assertRequestGetView(url, 200, self.admin)  # Admin
 
+        # Test invalid extent
+        new_data = copy.deepcopy(self.data)
+        new_data['extent'] = []
+        new_payload = {
+            'name': 'name_invalid_extent',
+            'data': json.dumps(new_data)
+        }
+        response = self.assertRequestPostView(url, 400, new_payload, self.admin)
+        self.assertEqual(
+            response.content,
+            (
+                b'Invalid extent, it seems the extent from '
+                b'GeoRepo is empty or not correct.'
+            )
+        )
+
+        # Test Indicator does not exist
+        new_data = copy.deepcopy(self.data)
+        new_data['indicators'] = [{'id': 9999999}]
+        new_payload = {
+            'name': 'name_invalid_indicator',
+            'data': json.dumps(new_data)
+        }
+        response = self.assertRequestPostView(url, 400, new_payload, self.admin)
+        self.assertEqual(
+            response.content,
+            b'Indicator with id 9999999 does not exist'
+        )
+
     def test_edit_view(self):
         """Test for edit view."""
         url = reverse(self.edit_url_tag, kwargs={'slug': 'test'})
@@ -175,6 +204,35 @@ class DashboardAdminViewTest(BaseViewTest.TestCase):
         self.assertEqual(self.resource.creator, self.resource_creator)
         self.assertEqual(self.resource.modified_by, self.creator)
         self.assertNotEqual(self.resource.version, last_version)
+
+        url = reverse(self.edit_url_tag, kwargs={'slug': self.resource.slug})
+        new_data = copy.deepcopy(self.data)
+        new_data['extent'] = []
+        new_payload = {
+            'name': 'name_invalid_extent',
+            'data': json.dumps(new_data)
+        }
+        response = self.assertRequestPostView(url, 400, new_payload, self.admin)
+        self.assertEqual(
+            response.content,
+            (
+                b'Invalid extent, it seems the extent from '
+                b'GeoRepo is empty or not correct.'
+            )
+        )
+
+        # Test Indicator does not exist
+        new_data = copy.deepcopy(self.data)
+        new_data['indicators'] = [{'id': 9999999}]
+        new_payload = {
+            'name': 'name_invalid_indicator',
+            'data': json.dumps(new_data)
+        }
+        response = self.assertRequestPostView(url, 400, new_payload, self.admin)
+        self.assertEqual(
+            response.content,
+            b'Indicator with id 9999999 does not exist'
+        )
 
     def test_detail_view(self):
         """Test for create view."""
@@ -259,3 +317,9 @@ class DashboardAdminViewTest(BaseViewTest.TestCase):
         self.assertEqual(self.resource.modified_by, self.resource.creator)
         last_version = self.resource.version
         self.assertEqual(self.resource.version, last_version)
+
+    def test_extent_invalid(self):
+        """Test for create view with invalid extent."""
+
+        url = reverse(self.create_url_tag)
+

--- a/django_project/frontend/views/admin/dashboard/edit.py
+++ b/django_project/frontend/views/admin/dashboard/edit.py
@@ -79,7 +79,10 @@ class DashboardEditView(
 
     def post(self, request, slug, **kwargs):
         """Create dashboard."""
-        data = DashboardForm.update_data(request.POST.copy().dict())
+        try:
+            data = DashboardForm.update_data(request.POST.copy().dict())
+        except ValueError as e:
+            return HttpResponseBadRequest(e)
         dashboard = get_object_or_404(
             Dashboard, slug=slug
         )

--- a/django_project/geosight/data/api/dashboard_bookmark.py
+++ b/django_project/geosight/data/api/dashboard_bookmark.py
@@ -84,9 +84,12 @@ class DashboardBookmarkAPI(APIView):
 
     def update_bookmark_data(self, request, dashboard):
         """Update Bookmark Data."""
-        data = DashboardBookmarkForm.update_data(
-            json.loads(request.POST.copy()['data'])
-        )
+        try:
+            data = DashboardBookmarkForm.update_data(
+                json.loads(request.POST.copy()['data'])
+            )
+        except ValueError as e:
+            return HttpResponseBadRequest(e)
         data['dashboard'] = dashboard.id
         if request.user.is_authenticated:
             data['creator'] = request.user

--- a/django_project/geosight/data/models/dashboard/dashboard.py
+++ b/django_project/geosight/data/models/dashboard/dashboard.py
@@ -551,13 +551,13 @@ class Dashboard(
                 )
             except (KeyError, ModelClass.DoesNotExist):
                 try:
-                    object = ObjectClass.objects.get(id=data['id'])
+                    obj = ObjectClass.objects.get(id=data['id'])
                     model = ModelClass(
                         dashboard=self,
-                        object=object
+                        object=obj
                     )
                 except ObjectClass.DoesNotExist:
-                    raise Exception(
+                    raise ValueError(
                         f"{ObjectClass.__name__} with id "
                         f"{data['id']} does not exist")
 


### PR DESCRIPTION
This is PR for https://github.com/unicef-drp/GeoSight/issues/1516
I make sure that the error occured suring update_data and save_relation is captured and returned to frontend

![Screenshot_20250206_165927](https://github.com/user-attachments/assets/82bb7f1f-7d7d-4ba5-b938-9bd1b05abb6e)
![Screenshot_20250206_162645](https://github.com/user-attachments/assets/4df809b6-2dd8-49fb-91ae-e8d3e2891200)
