### PR TITLE
Fix: app crashes when trying to select view when importing data via importer

### DIFF
--- a/django_project/frontend/src/pages/Admin/Components/Input/ReferenceLayerInput.jsx
+++ b/django_project/frontend/src/pages/Admin/Components/Input/ReferenceLayerInput.jsx
@@ -247,7 +247,7 @@ export const ReferenceLayerInput = forwardRef(
                     return row.identifier === reference
                   })
                   if (!referenceLayer && reference) {
-                    reference.dataset_levels = reference.dataset_levels.map(level => {
+                    reference.dataset_levels = reference.dataset_levels?.map(level => {
                       level.value = level.level
                       level.name = level.level_name
                       return level


### PR DESCRIPTION
This is PR for https://github.com/unicef-drp/GeoSight/issues/1519.
I added checking if dataset_levels exist before iterating it. I have also checked that if dataset level is empty, GeoSight will get it from GeoRepo ViewDetail

https://github.com/user-attachments/assets/83cfc7ac-17fc-4d73-ad0f-1065697d362f