### PR TITLE
Fix COG view in projcet view

### DIFF
--- a/django_project/frontend/src/pages/Dashboard/MapLibre/LayerType/RasterCog.jsx
+++ b/django_project/frontend/src/pages/Dashboard/MapLibre/LayerType/RasterCog.jsx
@@ -36,7 +36,7 @@ let sessions = {};
 /***
  * Render Raster Cog
  */
-export default function rasterCogLayer(map, id, data, setData, contextLayerData, popupFeatureFn, contextLayerOrder, isInit, setIsInit, requestSent) {
+export default function rasterCogLayer(map, id, data, setData, contextLayerData, popupFeatureFn, contextLayerOrder, isInit, setIsInit, requestSent = {}) {
   (
     async () => {
       const {
@@ -50,7 +50,7 @@ export default function rasterCogLayer(map, id, data, setData, contextLayerData,
         nodata_color,
         nodata_opacity,
       } = data?.styles;
-      if (requestSent.current) {
+      if (requestSent?.current) {
         return
       }
       const additional_ndt_val = additional_nodata ? parseFloat(additional_nodata) : additional_nodata;


### PR DESCRIPTION
This PR fixes COG not showing in project view. It is caused by requestSent, which is used to prevent multiple request to classification endpoint, is set only by https://github.com/unicef-drp/GeoSight-OS/blob/419d937e73353501dc0fbaf00c89ff65912429e3/django_project/frontend/src/pages/Admin/ContextLayer/StyleConfig/Map.jsx#L42.

In https://github.com/unicef-drp/GeoSight-OS/blob/419d937e73353501dc0fbaf00c89ff65912429e3/django_project/frontend/src/pages/Dashboard/MapLibre/Layers/ContextLayers/index.jsx#L333, requestSent is not provided. 

Since the duplicate request occured only in Style config, I set a default value for requestSent in this PR>