### PR TITLE
add flake8 vscode extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
     "vscode": {
       "extensions": [
         "ms-python.python",
-        "ms-azuretools.vscode-docker"
+        "ms-azuretools.vscode-docker",
+        "ms-python.flake8"
       ],
       "settings": {
         "terminal.integrated.shell.linux": "/bin/bash",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
     "files.eol": "\n",
     "editor.formatOnSave": true,
-    "remote.containers.openFolderOnCreate": "always"
+    "remote.containers.openFolderOnCreate": "always",
+    "flake8.args": [
+        "--config",
+        "setup.cfg"
+    ]
 }


### PR DESCRIPTION
Adding flake8 extension to dev container extension list. This will add the extension automatically when building the dev containers.

The error from flake8 can be seen from `Problems` tab.

<img width="584" alt="2025-05-25_20-55" src="https://github.com/user-attachments/assets/55827014-24fb-469d-8436-1ec2a60b8ccc" />

