### PR TITLE
fix complex color value in map editor

### DIFF
--- a/django_project/frontend/locales/react/en-US/common.json
+++ b/django_project/frontend/locales/react/en-US/common.json
@@ -55,6 +55,7 @@
     "createNew": "Create New {{pageName}}",
     "edit": "Edit",
     "deleteConfirmationMessage": "Are you sure want to delete {{item}}?",
+    "complexColorValueDetected": "Complex color value detected. Please edit in raw input mode.",
     "pageNameFormats": {
       "singular": {
         "dashboard": "Project",

--- a/django_project/frontend/locales/react/es-ES/common.json
+++ b/django_project/frontend/locales/react/es-ES/common.json
@@ -55,6 +55,7 @@
     "createNew": "Crear Nuevo {{pageName}}",
     "edit": "Editar",
     "deleteConfirmationMessage": "¿Estás seguro de querer eliminar {{item}}?",
+    "complexColorValueDetected": "Valor de color complejo detectado. Por favor edite en modo de entrada sin procesar.",
     "pageNameFormats": {
       "singular": {
         "dashboard": "Proyecto",

--- a/django_project/frontend/src/components/MapBoxStyleEditor/Input/index.tsx
+++ b/django_project/frontend/src/components/MapBoxStyleEditor/Input/index.tsx
@@ -159,13 +159,19 @@ export function ColorSelectorStyle({
         </label>
       </div>
       <div>
-        <ColorSelector
-          color={value}
-          onChange={(evt) => {
-            if (value === evt.target.value) return;
-            setValue(evt.target.value);
-          }}
-        />
+        {typeof inputValue === "string" ? (
+          <ColorSelector
+            color={value}
+            onChange={(evt) => {
+              if (value === evt.target.value) return;
+              setValue(evt.target.value);
+            }}
+          />
+        ) : (
+          <div style={{ color: "#666", fontStyle: "italic" }}>
+            {t("admin.complexColorValueDetected")}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Fix https://github.com/unicef-drp/GeoSight/issues/1732

The issue is because the complex value of 'circle-color' below:
```
"circle-color": [
                "case",
                [
                    "==",
                    [
                        "get",
                        "UNICEF Presence"
                    ],
                    "IDP Sites supported by UNICEF"
                ],
                "#FF6600",
                [
                    "==",
                    [
                        "get",
                        "UNICEF Presence"
                    ],
                    "IDP Sites not supported by UNICEF"
                ],
                "#00008B",
                "#000000"
            ],
```

When there is a complex value, I disable the color picker component and show a text message:
<img width="515" height="566" alt="2026-01-26_08-18" src="https://github.com/user-attachments/assets/4cab352d-e296-4eec-b829-78458891e8d6" />
