### PR TITLE
add env var LOGROTATE_CRONSCHEDULE to override the interval

### DIFF
--- a/deployment/.template.env
+++ b/deployment/.template.env
@@ -47,6 +47,9 @@ LOGROTATE_COPIES=14
 LOGROTATE_SIZE=100M
 # log rotate interval check
 LOGROTATE_INTERVAL=daily
+# log rotate cron schedule (uncomment to enable override the interval)
+# go-cron format e.g. 0 */15 * * * * for every 15 minutes
+# LOGROTATE_CRONSCHEDULE=
 
 # --------------------------------
 # ---------- APP DOMAIN ----------

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -176,3 +176,7 @@ services:
       - LOGROTATE_COPIES=${LOGROTATE_COPIES:-14}
       - LOGROTATE_SIZE=${LOGROTATE_SIZE:-10M}
       - LOGROTATE_INTERVAL=${LOGROTATE_INTERVAL:-daily}
+      # Logrotate cron schedule to override LOGROTATE_INTERVAL (optional)
+      # Format go-cron 6-field: second minute hour day month weekday
+      # e.g. 0 */15 * * * * for every 15 minutes
+      - LOGROTATE_CRONSCHEDULE=${LOGROTATE_CRONSCHEDULE}

--- a/deployment/docker/uwsgi.conf
+++ b/deployment/docker/uwsgi.conf
@@ -32,4 +32,4 @@ logto = /tmp/django.log
 memory-report = true
 harakiri = 2400
 buffer-size = 8192
-# disable-logging = True
+disable-logging = True


### PR DESCRIPTION
Fix invalid cron in the current config. The cron should be placed in new environment variable LOGROTATE_CRONSCHEDULE. LOGROTATE_INTERVAL variable can be set as hourly.


This PR will also disable django uwsgi logging to save spaces in the log volume.