### PR TITLE
Add v1 dashboard create endpoint via shared creation flow

### DIFF
--- a/django_project/frontend/views/admin/dashboard/create.py
+++ b/django_project/frontend/views/admin/dashboard/create.py
@@ -14,14 +14,14 @@ __author__ = 'irwan@kartoza.com'
 __date__ = '13/06/2023'
 __copyright__ = ('Copyright 2023, Unicef')
 
-from django.db import transaction
 from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect, reverse
 
 from azure_auth.backends import AzureAuthRequiredMixin
 from frontend.views.dashboard._base import BaseDashboardView
-from geosight.data.forms.dashboard import DashboardForm
-from geosight.data.models.dashboard import Dashboard
+from geosight.data.services.dashboard_create import (
+    create_dashboard_from_payload
+)
 from geosight.permission.access import RoleCreatorRequiredMixin
 
 
@@ -40,48 +40,23 @@ class DashboardCreateViewBase:
             otherwise an HTTP bad request response.
         :rtype: HttpResponseRedirect or HttpResponseBadRequest
         """
-        try:
-            data = DashboardForm.update_data(data, user=user)
-            if Dashboard.name_is_exist_of_all(data['slug']):
-                return HttpResponseBadRequest(
-                    f'Dashboard with this url shortcode : {data["slug"]} '
-                    f'is exist. Please choose other url shortcode.'
+        result = create_dashboard_from_payload(data, user, files)
+        if result.dashboard:
+            return redirect(
+                reverse(
+                    'admin-dashboard-edit-view',
+                    args=[result.dashboard.slug]
                 )
-        except (PermissionError, ValueError) as e:
-            return HttpResponseBadRequest(e)
+            )
 
-        # Get origin project
-        origin = None
-        origin_id = data.get('origin_id', None)
-        if origin_id:
-            origin = Dashboard.objects.get(id=origin_id)
-
-        data['creator'] = user
-        data['modified_by'] = user
-        form = DashboardForm(data, files)
-        if form.is_valid():
-            try:
-                with transaction.atomic():
-                    dashboard = form.save()
-                    if origin:
-                        dashboard.icon = origin.icon
-                        dashboard.save()
-                    dashboard.save_relations(data, is_create=True)
-                    dashboard.increase_version()
-                    return redirect(
-                        reverse(
-                            'admin-dashboard-edit-view',
-                            args=[dashboard.slug]
-                        )
-                    )
-            except Exception as e:
-                return HttpResponseBadRequest(e)
-        else:
+        if result.form_errors:
             errors = [
                 key + ' : ' + ''.join(value) for key, value in
-                form.errors.items()
+                result.form_errors.items()
             ]
             return HttpResponseBadRequest('<br>'.join(errors))
+
+        return HttpResponseBadRequest(result.error)
 
 
 class DashboardCreateView(

--- a/django_project/geosight/data/api/v1/dashboard.py
+++ b/django_project/geosight/data/api/v1/dashboard.py
@@ -14,6 +14,7 @@ __author__ = 'irwan@kartoza.com'
 __date__ = '08/01/2025'
 __copyright__ = ('Copyright 2025, Unicef')
 
+from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.decorators import action
@@ -22,6 +23,9 @@ from rest_framework.response import Response
 from core.api_utils import common_api_params, ApiTag, ApiParams
 from geosight.data.models.dashboard import Dashboard
 from geosight.data.serializer.dashboard import DashboardBasicSerializer
+from geosight.data.services.dashboard_create import (
+    create_dashboard_from_payload
+)
 from geosight.permission.access import ResourcePermissionDenied
 from .base import (
     BaseApiV1ResourceReadOnly,
@@ -39,6 +43,97 @@ class DashboardViewSet(
     serializer_class = DashboardBasicSerializer
     extra_exclude_fields = ['parameters']
     lookup_field = 'slug'
+
+    @swagger_auto_schema(
+        operation_id='dashboard-create',
+        tags=[ApiTag.DASHBOARD],
+        manual_parameters=[],
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                'name': openapi.Schema(type=openapi.TYPE_STRING),
+                'slug': openapi.Schema(type=openapi.TYPE_STRING),
+                'group': openapi.Schema(type=openapi.TYPE_STRING),
+                'geoField': openapi.Schema(type=openapi.TYPE_STRING),
+                'data': openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    description=(
+                        'Dashboard config payload. For multipart/form-data, '
+                        'send this field as a JSON-encoded string.'
+                    )
+                ),
+                'icon': openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    format=openapi.FORMAT_BINARY
+                )
+            },
+            required=['name', 'data']
+        ),
+        responses={
+            201: openapi.Response(
+                description='Created dashboard.',
+                schema=DashboardBasicSerializer
+            ),
+            400: openapi.Response(
+                description=(
+                    'Validation error. Response may be a field error map or '
+                    '{ "detail": "<error>" }.'
+                ),
+                schema=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        'detail': openapi.Schema(type=openapi.TYPE_STRING)
+                    }
+                )
+            ),
+            403: openapi.Response(
+                description='Forbidden for anonymous or non-creator users.',
+                schema=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        'detail': openapi.Schema(type=openapi.TYPE_STRING)
+                    }
+                )
+            )
+        },
+        operation_description=(
+            'Create a dashboard. Supports application/json and '
+            'multipart/form-data payloads. Requires authenticated creator role '
+            'or higher.'
+        )
+    )
+    def create(self, request, *args, **kwargs):  # noqa: DOC103
+        """
+        Create a dashboard using the shared dashboard creation flow.
+
+        :param request: The HTTP request object.
+        :type request: rest_framework.request.Request
+        :return: Created dashboard object or validation errors.
+        :rtype: rest_framework.response.Response
+        """
+        request_data = request.data.copy()
+        if hasattr(request_data, 'dict'):
+            payload = request_data.dict()
+        else:
+            payload = dict(request_data)
+
+        result = create_dashboard_from_payload(
+            payload, request.user, request.FILES
+        )
+        if result.dashboard:
+            serializer = self.get_serializer(result.dashboard)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+        if result.form_errors:
+            return Response(
+                result.form_errors,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        return Response(
+            {'detail': result.error},
+            status=status.HTTP_400_BAD_REQUEST
+        )
 
     @swagger_auto_schema(
         operation_id='dashboard-list',

--- a/django_project/geosight/data/api/v1/dashboard.py
+++ b/django_project/geosight/data/api/v1/dashboard.py
@@ -98,16 +98,17 @@ class DashboardViewSet(
         },
         operation_description=(
             'Create a dashboard. Supports application/json and '
-            'multipart/form-data payloads. Requires authenticated creator role '
-            'or higher.'
+            'multipart/form-data payloads. Requires authenticated creator '
+            'role or higher.'
         )
     )
-    def create(self, request, *args, **kwargs):  # noqa: DOC103
+    def create(self, request, *args, **kwargs):  # noqa: DOC101,DOC103
         """
         Create a dashboard using the shared dashboard creation flow.
 
         :param request: The HTTP request object.
         :type request: rest_framework.request.Request
+
         :return: Created dashboard object or validation errors.
         :rtype: rest_framework.response.Response
         """

--- a/django_project/geosight/data/services/dashboard_create.py
+++ b/django_project/geosight/data/services/dashboard_create.py
@@ -1,0 +1,90 @@
+# coding=utf-8
+"""
+GeoSight is UNICEF's geospatial web-based business intelligence platform.
+
+Contact : geosight-no-reply@unicef.org
+
+.. note:: This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+"""
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+
+from geosight.data.forms.dashboard import DashboardForm
+from geosight.data.models.dashboard import Dashboard
+
+User = get_user_model()
+INTERNAL_CREATE_ERROR = (
+    'Unable to create dashboard due to an internal error.'
+)
+
+
+@dataclass
+class DashboardCreateResult:
+    """Container for dashboard create flow output."""
+
+    dashboard: Optional[Dashboard] = None
+    error: Optional[str] = None
+    form_errors: Optional[Dict] = None
+
+
+def create_dashboard_from_payload(
+    payload: dict, user: User, files
+) -> DashboardCreateResult:
+    """
+    Create a dashboard using the shared UI/API creation flow.
+
+    :param payload: Incoming payload from UI or API request.
+    :type payload: dict
+    :param user: Authenticated user creating the dashboard.
+    :type user: User
+    :param files: Uploaded files dictionary.
+    :type files: MultiValueDict or dict
+    :return: The result containing a dashboard or error details.
+    :rtype: DashboardCreateResult
+    """
+    data = payload.copy()
+
+    try:
+        data = DashboardForm.update_data(data, user=user)
+        if Dashboard.name_is_exist_of_all(data['slug']):
+            return DashboardCreateResult(
+                error=(
+                    f'Dashboard with this url shortcode : {data["slug"]} '
+                    f'is exist. Please choose other url shortcode.'
+                )
+            )
+    except (PermissionError, ValueError, KeyError) as exc:
+        return DashboardCreateResult(error=str(exc))
+
+    origin = None
+    origin_id = data.get('origin_id', None)
+    if origin_id:
+        try:
+            origin = Dashboard.objects.get(id=origin_id)
+        except Dashboard.DoesNotExist:
+            return DashboardCreateResult(error='Origin project is not found.')
+
+    data['creator'] = user
+    data['modified_by'] = user
+    form = DashboardForm(data, files)
+    if not form.is_valid():
+        return DashboardCreateResult(form_errors=dict(form.errors.items()))
+
+    try:
+        with transaction.atomic():
+            dashboard = form.save()
+            if origin:
+                dashboard.icon = origin.icon
+                dashboard.save()
+            dashboard.save_relations(data, is_create=True)
+            dashboard.increase_version()
+            return DashboardCreateResult(dashboard=dashboard)
+    except Exception:
+        return DashboardCreateResult(error=INTERNAL_CREATE_ERROR)

--- a/django_project/geosight/data/tests/api/v1/dashboard.py
+++ b/django_project/geosight/data/tests/api/v1/dashboard.py
@@ -14,11 +14,17 @@ __author__ = 'irwan@kartoza.com'
 __date__ = '08/01/2025'
 __copyright__ = ('Copyright 2025, Unicef')
 
+import copy
+import json
 import urllib.parse
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from geosight.data.models.dashboard import Dashboard, DashboardGroup
+from geosight.data.services.dashboard_create import INTERNAL_CREATE_ERROR
+from geosight.georepo.models.reference_layer import ReferenceLayerView
 from geosight.permission.models.factory import PERMISSIONS
 from geosight.permission.tests._base import BasePermissionTest
 
@@ -28,9 +34,34 @@ User = get_user_model()
 class DashboardPermissionTest(BasePermissionTest.TestCase):
     """Test for Dashboard API."""
 
+    create_payload_data = {
+        'reference_layer': 'AAAA',
+        'indicator_layers': [],
+        'indicator_layers_structure': {'children': []},
+        'indicators': [],
+        'basemaps_layers': [],
+        'basemaps_layers_structure': {'children': []},
+        'context_layers': [],
+        'context_layers_structure': {'children': []},
+        'extent': [0, 0, 0, 0],
+        'widgets': [],
+        'widgets_structure': {},
+        'filters': {},
+        'permission': {
+            'organization_permission': 'None',
+            'public_permission': 'None',
+            'user_permissions': [],
+            'group_permissions': [],
+        }
+    }
+
     def setUp(self):
         """To setup test."""
         super().setUp()
+        ReferenceLayerView.objects.get_or_create(
+            identifier='AAAA',
+            name='AAAA'
+        )
 
         # Resource layer attribute
         self.resource_1 = Dashboard.permissions.create(
@@ -338,6 +369,149 @@ class DashboardPermissionTest(BasePermissionTest.TestCase):
             url, 200, user=self.creator_in_group
         )
         self.assertEqual(response.json(), ['Group 3'])
+
+    def test_create_api_invalid_payload_returns_validation_error(self):
+        """Test create API validation message for invalid payload."""
+        url = reverse('dashboards-list')
+        payload = {
+            'name': 'invalid-payload-dashboard',
+            'slug': 'invalid-payload-dashboard',
+            'data': json.dumps({})
+        }
+        response = self.assertRequestPostView(
+            url, 400, payload, user=self.creator
+        )
+        self.assertIn('detail', response.json())
+        self.assertIn('extent', response.json()['detail'])
+
+    def test_create_api_denies_anonymous_user(self):
+        """Ensure anonymous users cannot create dashboards."""
+        url = reverse('dashboards-list')
+        payload_data = copy.deepcopy(self.create_payload_data)
+        payload_data['slug'] = 'anonymous-denied-dashboard'
+        payload = {
+            'name': 'anonymous denied dashboard',
+            'slug': 'anonymous-denied-dashboard',
+            'data': json.dumps(payload_data)
+        }
+
+        response = self.assertRequestPostView(url, 403, payload)
+        self.assertIn('detail', response.json())
+
+    def test_create_api_denies_contributor_user(self):
+        """Ensure contributor users cannot create dashboards."""
+        url = reverse('dashboards-list')
+        payload_data = copy.deepcopy(self.create_payload_data)
+        payload_data['slug'] = 'contributor-denied-dashboard'
+        payload = {
+            'name': 'contributor denied dashboard',
+            'slug': 'contributor-denied-dashboard',
+            'data': json.dumps(payload_data)
+        }
+
+        response = self.assertRequestPostView(
+            url, 403, payload, user=self.contributor
+        )
+        self.assertIn('detail', response.json())
+
+    def test_create_api_returns_response_contract_fields(self):
+        """Ensure create API returns expected v1 serializer contract."""
+        url = reverse('dashboards-list')
+        slug = 'contract-dashboard'
+        payload_data = copy.deepcopy(self.create_payload_data)
+        payload_data['slug'] = slug
+        payload = {
+            'name': 'contract dashboard',
+            'slug': slug,
+            'group': 'Contract Group',
+            'data': json.dumps(payload_data)
+        }
+
+        response = self.assertRequestPostView(
+            url, 201, payload, user=self.creator
+        )
+        body = response.json()
+
+        expected_fields = {
+            'id', 'slug', 'icon', 'thumbnail', 'name',
+            'description', 'group', 'category', 'permission',
+            'reference_layer', 'creator', 'featured',
+            'created_at', 'created_by', 'modified_at', 'modified_by'
+        }
+        self.assertTrue(expected_fields.issubset(set(body.keys())))
+        self.assertEqual(body['id'], slug)
+        self.assertEqual(body['slug'], slug)
+        self.assertEqual(body['name'], 'contract dashboard')
+        self.assertEqual(body['group'], 'Contract Group')
+        self.assertEqual(body['category'], 'Contract Group')
+        self.assertEqual(
+            body['reference_layer'],
+            ReferenceLayerView.objects.get(identifier='AAAA').id
+        )
+        self.assertEqual(body['creator'], self.creator.id)
+        self.assertEqual(body['featured'], False)
+        self.assertEqual(body['created_by'], self.creator.username)
+        self.assertEqual(body['modified_by'], self.creator.username)
+
+        for permission_key in ['list', 'read', 'edit', 'share', 'delete']:
+            self.assertIn(permission_key, body['permission'])
+
+        Dashboard.objects.get(slug=slug).delete()
+
+    def test_create_api_accepts_application_json_payload(self):
+        """Ensure create API accepts application/json payloads."""
+        url = reverse('dashboards-list')
+        slug = 'json-contract-dashboard'
+        payload_data = copy.deepcopy(self.create_payload_data)
+        payload_data['slug'] = slug
+        payload = {
+            'name': 'json contract dashboard',
+            'slug': slug,
+            'group': 'JSON Contract Group',
+            'data': payload_data
+        }
+
+        response = self.assertRequestPostView(
+            url, 201, json.dumps(payload), user=self.creator,
+            content_type=self.JSON_CONTENT
+        )
+        body = response.json()
+
+        self.assertEqual(body['id'], slug)
+        self.assertEqual(body['slug'], slug)
+        self.assertEqual(body['name'], 'json contract dashboard')
+        self.assertEqual(body['group'], 'JSON Contract Group')
+        self.assertEqual(
+            body['reference_layer'],
+            ReferenceLayerView.objects.get(identifier='AAAA').id
+        )
+
+        Dashboard.objects.get(slug=slug).delete()
+
+    def test_create_api_rolls_back_if_save_relations_fails(self):
+        """Ensure dashboard create is transactional across relations."""
+        url = reverse('dashboards-list')
+        slug = 'rollback-dashboard'
+        payload_data = copy.deepcopy(self.create_payload_data)
+        payload_data['slug'] = slug
+        payload = {
+            'name': 'rollback-dashboard',
+            'slug': slug,
+            'data': json.dumps(payload_data)
+        }
+
+        with patch.object(
+            Dashboard,
+            'save_relations',
+            side_effect=RuntimeError('save relations failure')
+        ):
+            response = self.assertRequestPostView(
+                url, 400, payload, user=self.creator
+            )
+
+        self.assertIn('detail', response.json())
+        self.assertEqual(response.json()['detail'], INTERNAL_CREATE_ERROR)
+        self.assertFalse(Dashboard.objects.filter(slug=slug).exists())
 
     def test_feature(self):
         """Test Feature API."""

--- a/playwright/ci-test/tests/contributor/project_creation/api_v1_create_denied.ts
+++ b/playwright/ci-test/tests/contributor/project_creation/api_v1_create_denied.ts
@@ -1,0 +1,72 @@
+import { expect, request as playwrightRequest, test } from "@playwright/test";
+
+const csrfTokenFromContext = async (page: any): Promise<string> => {
+  const cookies = await page.context().cookies();
+  const csrfToken = cookies.find((cookie: any) => cookie.name === "csrftoken");
+  return csrfToken?.value || "";
+};
+
+const waitForAdminProjectListReady = async (page: any): Promise<void> => {
+  try {
+    await expect(page.getByText("Create New Project")).toBeVisible({
+      timeout: 10_000,
+    });
+  } catch {
+    await expect(page.getByText("Project Name")).toBeVisible({
+      timeout: 60_000,
+    });
+  }
+  await expect(
+    page.locator('.AdminContent [role="progressbar"]:visible'),
+  ).toHaveCount(0, {
+    timeout: 60_000,
+  });
+};
+
+test.describe("Dashboard v1 create API permissions", () => {
+  test("Anonymous cannot create dashboard via v1 endpoint", async ({
+    baseURL,
+  }) => {
+    const anonymousContext = await playwrightRequest.newContext({
+      baseURL: baseURL || "http://localhost:2000",
+    });
+
+    const response = await anonymousContext.post("/api/v1/dashboards/", {
+      form: {
+        name: "Anonymous Create Attempt",
+        slug: `anonymous-create-${Date.now()}`,
+        data: JSON.stringify({}),
+      },
+    });
+
+    expect(response.status()).toBe(403);
+    await response.json();
+
+    await anonymousContext.dispose();
+  });
+
+  test("Contributor cannot create dashboard via v1 endpoint", async ({
+    page,
+  }) => {
+    await page.goto("/admin/project/");
+    await waitForAdminProjectListReady(page);
+
+    const csrfToken = await csrfTokenFromContext(page);
+    expect(csrfToken.length).toBeGreaterThan(0);
+
+    const response = await page.request.post("/api/v1/dashboards/", {
+      headers: {
+        "X-CSRFToken": csrfToken,
+        Referer: page.url(),
+      },
+      form: {
+        name: "Unauthorized Create Attempt",
+        slug: `unauthorized-create-${Date.now()}`,
+        data: JSON.stringify({}),
+      },
+    });
+
+    expect(response.status()).toBe(403);
+    await response.json();
+  });
+});

--- a/playwright/ci-test/tests/creator/project_creation/api_v1_create.ts
+++ b/playwright/ci-test/tests/creator/project_creation/api_v1_create.ts
@@ -1,0 +1,181 @@
+import { expect, test } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+
+const SOURCE_DASHBOARD_SLUG = "demo-geosight-project";
+const TEST_ICON_PATH = path.resolve(
+  __dirname,
+  "../../../../../django_project/geosight/data_restorer/demo_data/countries_data/icon.png",
+);
+const TEST_ICON_BUFFER = fs.readFileSync(TEST_ICON_PATH);
+
+const waitForAdminProjectListReady = async (page: any): Promise<void> => {
+  try {
+    await expect(page.getByText("Create New Project")).toBeVisible({
+      timeout: 10_000,
+    });
+  } catch {
+    await expect(page.getByText("Project Name")).toBeVisible({
+      timeout: 60_000,
+    });
+  }
+  await expect(
+    page.locator('.AdminContent [role="progressbar"]:visible'),
+  ).toHaveCount(0, {
+    timeout: 60_000,
+  });
+};
+
+const csrfTokenFromContext = async (page: any): Promise<string> => {
+  const cookies = await page.context().cookies();
+  const csrfToken = cookies.find((cookie: any) => cookie.name === "csrftoken");
+  return csrfToken?.value || "";
+};
+
+const buildPayloadFromRealDashboard = async (
+  page: any,
+  name: string,
+  slug: string,
+): Promise<Record<string, string>> => {
+  const sourceResponse = await page.request.get(
+    `/api/dashboard/${SOURCE_DASHBOARD_SLUG}/data`,
+  );
+  expect(sourceResponse.ok()).toBeTruthy();
+
+  const sourceDashboard = await sourceResponse.json();
+  const referenceLayerIdentifier =
+    sourceDashboard?.reference_layer?.identifier || "";
+  const groupName = sourceDashboard?.group || "Test";
+
+  const nestedData = {
+    ...sourceDashboard,
+    name,
+    slug,
+    reference_layer: referenceLayerIdentifier,
+    geoField:
+      sourceDashboard?.geo_field ||
+      sourceDashboard?.geoField ||
+      "geometry_code",
+    featured: false,
+  };
+
+  return {
+    name,
+    slug,
+    group: groupName,
+    geoField: nestedData.geoField,
+    data: JSON.stringify(nestedData),
+  };
+};
+
+test.describe("Dashboard v1 create API", () => {
+  test("Creator can create dashboard using real dashboard payload", async ({
+    page,
+  }) => {
+    await page.goto("/admin/project/");
+    await waitForAdminProjectListReady(page);
+
+    const csrfToken = await csrfTokenFromContext(page);
+    expect(csrfToken.length).toBeGreaterThan(0);
+
+    const uniqueSuffix = Date.now();
+    const name = `API V1 Create ${uniqueSuffix}`;
+    const slug = `api-v1-create-${uniqueSuffix}`;
+    const payload = await buildPayloadFromRealDashboard(page, name, slug);
+
+    const createResponse = await page.request.post("/api/v1/dashboards/", {
+      headers: {
+        "X-CSRFToken": csrfToken,
+        Referer: page.url(),
+      },
+      form: payload,
+    });
+
+    expect(createResponse.status()).toBe(201);
+    const createdDashboard = await createResponse.json();
+    expect(createdDashboard.slug).toBe(slug);
+    expect(createdDashboard.name).toBe(name);
+
+    const deleteResponse = await page.request.delete(
+      `/api/v1/dashboards/${slug}/`,
+      {
+        headers: {
+          "X-CSRFToken": csrfToken,
+          Referer: page.url(),
+        },
+      },
+    );
+    expect(deleteResponse.status()).toBe(204);
+  });
+
+  test("Creator can create dashboard with multipart icon upload", async ({
+    page,
+  }) => {
+    await page.goto("/admin/project/");
+    await waitForAdminProjectListReady(page);
+
+    const csrfToken = await csrfTokenFromContext(page);
+    expect(csrfToken.length).toBeGreaterThan(0);
+
+    const uniqueSuffix = Date.now() + 1;
+    const name = `API V1 Multipart ${uniqueSuffix}`;
+    const slug = `api-v1-multipart-${uniqueSuffix}`;
+    const payload = await buildPayloadFromRealDashboard(page, name, slug);
+
+    const createResponse = await page.request.post("/api/v1/dashboards/", {
+      headers: {
+        "X-CSRFToken": csrfToken,
+        Referer: page.url(),
+      },
+      multipart: {
+        ...payload,
+        icon: {
+          name: "integration-icon.png",
+          mimeType: "image/png",
+          buffer: TEST_ICON_BUFFER,
+        },
+      },
+    });
+
+    expect(createResponse.status()).toBe(201);
+    const createdDashboard = await createResponse.json();
+    expect(createdDashboard.slug).toBe(slug);
+
+    const deleteResponse = await page.request.delete(
+      `/api/v1/dashboards/${slug}/`,
+      {
+        headers: {
+          "X-CSRFToken": csrfToken,
+          Referer: page.url(),
+        },
+      },
+    );
+    expect(deleteResponse.status()).toBe(204);
+  });
+
+  test("Creator receives validation error for invalid payload", async ({
+    page,
+  }) => {
+    await page.goto("/admin/project/");
+    await waitForAdminProjectListReady(page);
+
+    const csrfToken = await csrfTokenFromContext(page);
+    expect(csrfToken.length).toBeGreaterThan(0);
+
+    const response = await page.request.post("/api/v1/dashboards/", {
+      headers: {
+        "X-CSRFToken": csrfToken,
+        Referer: page.url(),
+      },
+      form: {
+        name: `API V1 Invalid ${Date.now()}`,
+        slug: `api-v1-invalid-${Date.now()}`,
+        data: JSON.stringify({}),
+      },
+    });
+
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body.detail).toContain("extent");
+  });
+});


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Yes. API v1 could list and retrieve dashboards, but could not create them, which blocked API-first workflows and forced UI-only creation.

**Describe the solution you'd like**
This PR adds `POST /api/v1/dashboards/` in API v1 by reusing the existing dashboard creation flow rather than introducing a second create path.

Implemented behavior:
- Create support in v1 dashboard endpoint (`django_project/geosight/data/api/v1/dashboard.py`).
- Shared create service reused by both UI and API (`django_project/geosight/data/services/dashboard_create.py`, wired from `django_project/frontend/views/admin/dashboard/create.py`).
- Supports both form/json-style payload parsing and multipart (including optional icon upload).
- Permission behavior aligned with existing creator+ expectations; anonymous/non-creator creation denied.
- Transaction-safe create flow (rollback on relation-save failures).
- API docs/schema updated to reflect actual request/response contract for create.

**Describe alternatives you've considered**
- Keep creation UI-only: rejected because it does not enable API automation.
- Build separate API-only create flow: rejected to avoid drift from existing UI business logic.
- Redesign payload model first: rejected to keep change surface small and ship endpoint now.

**Additional context**
Design/implementation alignment used from our plan:
- Thin API layer; business logic in shared service.
- Reuse over rewrite.
- Contract/documentation updates in the same branch as behavior changes.
- Real integration verification on a running local GeoSight instance.

Scope delivered in this PR:
- Add create support to v1 dashboards endpoint.
- Reuse dashboard creation flow used by UI.
- Add targeted tests for success, permission denial, validation, multipart, and rollback.
- Update create endpoint docs/schema.

Out of scope (unchanged):
- Update/PATCH semantics.
- Full payload redesign.
- Unrelated dashboard permission/feature changes.
- Generic map viewer save-as-URL workflow.

Implemented acceptance checklist:
- [x] `POST /api/v1/dashboards/` is available in API v1.
- [x] Endpoint requires authentication and creator+ role.
- [x] Anonymous/public and non-creator requests are denied.
- [x] JSON and multipart create flows both work.
- [x] Failed relation save does not persist partial dashboard data.
- [x] API docs reflect real request and response behavior.
- [x] Tests cover happy path and failure cases.

Verification executed for this PR:
- `docker exec geosight_branch_dev python manage.py test geosight.data.tests.api.v1.dashboard.DashboardPermissionTest --keepdb --noinput` → `OK (14 tests)`.
- `cd playwright/ci-test && npx playwright test tests/creator/project_creation/api_v1_create.ts tests/contributor/project_creation/api_v1_create_denied.ts --project=creator-chromium --project=contributor-chromium` → `PASS (7) FAIL (0)`.
- Existing admin project creation suite was also run as a local regression signal and failed in this local seed baseline (tracked in issue comment), not in the targeted endpoint suites.

Closes #652
